### PR TITLE
Fix "contrinue" typo at line 3984

### DIFF
--- a/yakko
+++ b/yakko
@@ -3981,7 +3981,7 @@ yakko-infra-operations() {
 			echo -n "Enter the new RAM size (MiB) for node \"${NODETORESIZE}\": "
 			read NEWRAMSIZE
 
-			[ -z "$NEWRAMSIZE" ] && contrinue
+			[ -z "$NEWRAMSIZE" ] && continue
 
 			! [[ $NEWRAMSIZE =~ $NUMBERRE ]] && {
 				echo "Error: Not a number. Try again..."


### PR DESCRIPTION
Fix "contrinue" typo at line 3984.

Discovered when trying to get out of changing the RAM size of a node.